### PR TITLE
Add parsing of OpenStreetMap links to allow accurately setting locations for HC

### DIFF
--- a/api/factory/runs.py
+++ b/api/factory/runs.py
@@ -9,6 +9,7 @@
 
 from datetime import datetime
 import html
+import re
 from typing import List, Any
 
 from pydantic import ValidationError
@@ -260,6 +261,14 @@ def get_hash_runs(params: HashParams) -> List[Hash]:
                 lat=hash_data.get("geo_lat"),
                 long=hash_data.get("geo_long")
             )
+
+        # Parse coordinates out of OSM link (e.g. https://www.openstreetmap.org/#map=15/52.4512/13.4471)
+        if hash_data.get("geo_map_url") is not None:
+            pattern = r"#map=\d+/(?P<latitude>[-]?\d+\.\d+)/(?P<longitude>[-]?\d+\.\d+)"
+            match = re.search(pattern, hash_data.get("geo_map_url"))
+            if match:
+                hash_data["geo_lat"] = float(match.group("latitude"))
+                hash_data["geo_long"] = float(match.group("longitude"))
 
         # parse event data
         try:


### PR DESCRIPTION
I added a simple parsing based on RegEx to factory/runs.py, which allows manually copying an OpenStreetMap link into the Location URL field on Wordpress, that is then hopefully used as a base for defining the location of the events in HC. This would also allow precisely defining meeting points for hashes, while the displayed location could still be a station name, for example.